### PR TITLE
Update _wapi.coffee

### DIFF
--- a/_wapi.coffee
+++ b/_wapi.coffee
@@ -20,7 +20,6 @@ module.exports = {
 """)
     process.exit()
 
-Wilddog = require("wilddog")
 WilddogTokenGenerator = require("wilddog-token-generator")
 request = require('request')
 


### PR DESCRIPTION
删除对 wilddog 模块的引用。因为似乎没有用到，并且package.json 中也不存在
